### PR TITLE
Update PhpFpm.php to fix issue with default php version for arch

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -400,6 +400,6 @@ class PhpFpm
      */
     private function getDefaultVersion(): string
     {
-        return $this->normalizePhpVersion(PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION);
+        return $this->pm instanceof \Valet\PackageManagers\Pacman ? '' : $this->normalizePhpVersion(PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION);
     }
 }


### PR DESCRIPTION
Changed the default php version for arch based systems to be an empty string ```''```.

since pacman can only install ```php``` and not ```php-{version}```