### PR TITLE
Updated the default path for ca-certificates

### DIFF
--- a/cli/Valet/Contracts/PackageManager.php
+++ b/cli/Valet/Contracts/PackageManager.php
@@ -35,6 +35,11 @@ interface PackageManager
     public function getPhpFpmName(string $version): string;
 
     /**
+     * Get Php fpm service name from distro
+     */
+    public function getCaCertificatesPath(): string;
+
+    /**
      * Get Php extension pattern from distro
      */
     public function getPhpExtensionPrefix(string $version): string;

--- a/cli/Valet/PackageManagers/Apt.php
+++ b/cli/Valet/PackageManagers/Apt.php
@@ -117,6 +117,14 @@ class Apt implements PackageManager
     }
 
     /**
+     * Get the `ca-certificates` directory
+     */
+    public function getCaCertificatesPath(): string
+    {
+        return '/usr/share/ca-certificates';
+    }
+
+    /**
      * Determine php extension pattern.
      */
     public function getPhpExtensionPrefix(string $version): string

--- a/cli/Valet/PackageManagers/Dnf.php
+++ b/cli/Valet/PackageManagers/Dnf.php
@@ -112,6 +112,14 @@ class Dnf implements PackageManager
     }
 
     /**
+     * Get the `ca-certificates` directory
+     */
+    public function getCaCertificatesPath(): string
+    {
+        return '/usr/share/pki/ca-trust-source';
+    }
+
+    /**
      * Determine php extension pattern.
      */
     public function getPhpExtensionPrefix(string $version): string

--- a/cli/Valet/PackageManagers/Eopkg.php
+++ b/cli/Valet/PackageManagers/Eopkg.php
@@ -116,6 +116,14 @@ class Eopkg implements PackageManager
     }
 
     /**
+     * Get the `ca-certificates` directory
+     */
+    public function getCaCertificatesPath(): string
+    {
+        return '/usr/share/ca-certificates';
+    }
+
+    /**
      * Determine php extension pattern.
      */
     public function getPhpExtensionPrefix(string $version): string

--- a/cli/Valet/PackageManagers/PackageKit.php
+++ b/cli/Valet/PackageManagers/PackageKit.php
@@ -116,6 +116,14 @@ class PackageKit implements PackageManager
     }
 
     /**
+     * Get the `ca-certificates` directory
+     */
+    public function getCaCertificatesPath(): string
+    {
+        return '/usr/share/pki/ca-trust-source';
+    }
+
+    /**
      * Determine php extension pattern.
      */
     public function getPhpExtensionPrefix(string $version): string

--- a/cli/Valet/PackageManagers/Pacman.php
+++ b/cli/Valet/PackageManagers/Pacman.php
@@ -122,6 +122,14 @@ class Pacman implements PackageManager
     }
 
     /**
+     * Get the `ca-certificates` directory
+     */
+    public function getCaCertificatesPath(): string
+    {
+        return '/usr/share/ca-certificates';
+    }
+
+    /**
      * Determine php extension pattern.
      */
     public function getPhpExtensionPrefix(string $version): string

--- a/cli/Valet/PackageManagers/Yum.php
+++ b/cli/Valet/PackageManagers/Yum.php
@@ -115,6 +115,14 @@ class Yum implements PackageManager
     }
 
     /**
+     * Get the `ca-certificates` directory
+     */
+    public function getCaCertificatesPath(): string
+    {
+        return '/usr/share/pki/ca-trust-source';
+    }
+
+    /**
      * Determine php extension pattern.
      */
     public function getPhpExtensionPrefix(string $version): string


### PR DESCRIPTION
The original path ```/usr/local/share/ca-certificates``` causes an error whenever ```valet install``` command is executed since the directory may not exist as this location varies for various systems. This PR addresses this issue with a valid existing directory.