### PR TITLE
fix(status): Enabled status display of services used by valet.

### DIFF
--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -54,6 +54,14 @@ class DnsMasq
     }
 
     /**
+     * DnsMasq service status.
+     */
+    public function status(): void
+    {
+        $this->sm->printStatus('dnsmasq');
+    }
+
+    /**
      * Restart the DnsMasq service.
      */
     public function restart(): void

--- a/cli/Valet/Facades/DnsMasq.php
+++ b/cli/Valet/Facades/DnsMasq.php
@@ -10,6 +10,7 @@ namespace Valet\Facades;
  * @method static void restart()
  * @method static void updateDomain(string $newDomain)
  * @method static void uninstall()
+ * @method static void status()
  */
 class DnsMasq extends Facade
 {

--- a/cli/Valet/Facades/Mysql.php
+++ b/cli/Valet/Facades/Mysql.php
@@ -9,6 +9,7 @@ namespace Valet\Facades;
  * @method static void        stop()
  * @method static void        restart()
  * @method static void        uninstall()
+ * @method static void        status()
  * @method static void        configure(bool $force = false)
  * @method static bool        createDatabase(string $name)
  * @method static bool        dropDatabase(string $name)

--- a/cli/Valet/Facades/ValetRedis.php
+++ b/cli/Valet/Facades/ValetRedis.php
@@ -9,6 +9,7 @@ namespace Valet\Facades;
  * @method static void uninstall()
  * @method static void restart()
  * @method static void stop()
+ * @method static void status()
  */
 class ValetRedis extends Facade
 {

--- a/cli/Valet/Mysql.php
+++ b/cli/Valet/Mysql.php
@@ -99,6 +99,14 @@ class Mysql
     }
 
     /**
+     * Mysql service stauts.
+     */
+    public function status(): void
+    {
+        $this->sm->printStatus($this->serviceName());
+    }
+
+    /**
      * Restart the Mysql service.
      */
     public function restart(): void

--- a/cli/Valet/ValetRedis.php
+++ b/cli/Valet/ValetRedis.php
@@ -70,6 +70,14 @@ class ValetRedis
     }
 
     /**
+     * Redis service status.
+     */
+    public function status(): void
+    {
+        $this->sm->printStatus($this->pm->packageName('redis'));
+    }
+
+    /**
      * Prepare for uninstall.
      */
     public function uninstall(): void

--- a/cli/app.php
+++ b/cli/app.php
@@ -249,8 +249,12 @@ if (is_dir(VALET_HOME_PATH)) {
      * Remove the current working directory to paths configuration.
      */
     $app->command('status', function () {
-        PhpFpm::status();
+        DnsMasq::status();
         Nginx::status();
+        PhpFpm::status();
+        Mysql::status();
+        Mailpit::status();
+        ValetRedis::status();
     })->descriptions('View Valet service status');
 
     /**


### PR DESCRIPTION
Prior to this PR, valet shows the status of ```php-fpm``` and
```nginx``` only. I once had an issue where i disabled ```dnsmasq```
(using ```systemctl disable dnsmasq```)  without knowing and got valet
unusable for days before rechecking the docs and realising dnsmasq was
required.

This PR addresses the issue above by diplaying all of valet services and
their status using the ```valet status``` command