### PR TITLE
Allow password to be nullable in validateCredentials

### DIFF
--- a/cli/Valet/Mysql.php
+++ b/cli/Valet/Mysql.php
@@ -311,7 +311,7 @@ class Mysql
     /**
      * Validate Username & Password.
      */
-    private function validateCredentials(string $username, string $password): bool
+    private function validateCredentials(string $username, ?string $password): bool
     {
         try {
             // Create connection


### PR DESCRIPTION
Some people like to use MySQL without a password for speed of access